### PR TITLE
Camada do Entity Framework

### DIFF
--- a/EventPlanApp.Domain/Entities/Evento.cs
+++ b/EventPlanApp.Domain/Entities/Evento.cs
@@ -87,6 +87,8 @@ namespace EventPlanApp.Domain.Entities
 
         public ICollection<Ingresso> Ingressos { get; set; }
 
+        public ICollection<UsuarioFinal> UsuariosFinais { get; set; }
+
         [Required(ErrorMessage = "A organização é obrigatória.")]
         public int OrganizacaoId { get; set; }
 

--- a/EventPlanApp.Domain/Entities/Ingresso.cs
+++ b/EventPlanApp.Domain/Entities/Ingresso.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -27,6 +28,17 @@ namespace EventPlanApp.Domain.Entities
         public DateTime Data { get; set; }
 
         public bool VIP { get; set; }
+
+        public int UsuarioFinalId { get; set; }
+
+        [ForeignKey("UsuarioFinalId")]
+        public UsuarioFinal UsuarioFinal { get; set; }
+
+        [Required(ErrorMessage = "O evento é obrigatório.")]
+        public int EventoId { get; set; }
+
+        [ForeignKey("EventoId")]
+        public Evento Evento { get; set; }
     }
 
 }

--- a/EventPlanApp.Domain/Entities/Organizacao.cs
+++ b/EventPlanApp.Domain/Entities/Organizacao.cs
@@ -47,10 +47,12 @@ namespace EventPlanApp.Domain.Entities
         [Range(0, 5, ErrorMessage = "A nota média deve estar entre 0 e 5.")]
         public decimal NotaMedia { get; set; }
 
-        public ICollection<Evento> Eventos { get; set; }
 
         [Required]
         public int UsuarioAdmId { get; set; }
-        public UsuarioAdm UsuarioAdm { get; set; }
+
+        public virtual ICollection<UsuarioAdm> UsuariosAdm { get; set; } = new List<UsuarioAdm>();
+
+        public virtual ICollection<Evento> Eventos { get; set; } = new List<Evento>();
     }
 }

--- a/EventPlanApp.Domain/Entities/UsuarioFinal.cs
+++ b/EventPlanApp.Domain/Entities/UsuarioFinal.cs
@@ -74,5 +74,7 @@ namespace EventPlanApp.Domain.Entities
         public string Preferencias03 { get; set; }
 
         public ICollection<Ingresso> Ingressos { get; set; }
+
+        public virtual ICollection<Evento> Eventos { get; set; } = new List<Evento>();
     }
 }

--- a/EventPlanApp.Infra.Data/Context/EventPlanContext.cs
+++ b/EventPlanApp.Infra.Data/Context/EventPlanContext.cs
@@ -1,0 +1,66 @@
+﻿using EventPlanApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+public class EventPlanContext : DbContext
+{
+    public EventPlanContext(DbContextOptions<EventPlanContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<UsuarioFinal> UsuariosFinais { get; set; }
+    public DbSet<UsuarioAdm> UsuariosAdm { get; set; }
+    public DbSet<Organizacao> Organizacoes { get; set; }
+    public DbSet<Evento> Eventos { get; set; }
+    public DbSet<Ingresso> Ingressos { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Mapeamento UsuarioFinal
+        modelBuilder.Entity<UsuarioFinal>()
+            .HasKey(u => u.Id);
+
+        modelBuilder.Entity<UsuarioFinal>()
+            .HasMany(u => u.Ingressos)
+            .WithOne(i => i.UsuarioFinal)
+            .HasForeignKey(i => i.UsuarioFinalId)
+            .OnDelete(DeleteBehavior.Cascade); // Excluir ingressos se o usuário final for excluído
+
+        // Mapeamento UsuarioAdm
+        modelBuilder.Entity<UsuarioAdm>()
+            .HasKey(a => a.AdmId);
+
+        modelBuilder.Entity<UsuarioAdm>()
+            .HasMany(a => a.Organizacoes)
+            .WithMany(o => o.UsuariosAdm);
+
+        // Mapeamento Organizacao
+        modelBuilder.Entity<Organizacao>()
+            .HasKey(o => o.OrganizacaoId);
+
+        modelBuilder.Entity<Organizacao>()
+            .HasMany(o => o.Eventos)
+            .WithOne(e => e.Organizacao)
+            .HasForeignKey(e => e.OrganizacaoId)
+            .OnDelete(DeleteBehavior.Cascade); // Excluir eventos se a organização for excluída
+
+        // Mapeamento Evento
+        modelBuilder.Entity<Evento>()
+            .HasKey(e => e.EventoId);
+
+        modelBuilder.Entity<Evento>()
+            .HasMany(e => e.UsuariosFinais)
+            .WithMany(u => u.Eventos);
+
+        // Mapeamento Ingresso
+        modelBuilder.Entity<Ingresso>()
+            .HasKey(i => i.IngressoId);
+
+        modelBuilder.Entity<Ingresso>()
+            .HasOne(i => i.Evento)
+            .WithMany()
+            .HasForeignKey(i => i.EventoId)
+            .OnDelete(DeleteBehavior.Cascade); // Excluir ingressos se o evento for excluído
+    }
+}
+


### PR DESCRIPTION
- [ ] Construtor: O construtor aceita DbContextOptions<EventPlanContext>, permitindo que você passe as configurações necessárias para a conexão com o banco de dados.

- [ ] DbSets: Define propriedades do tipo DbSet para cada uma das entidades (UsuarioFinal, UsuarioAdm, Organizacao, Evento, Ingresso). Essas propriedades representam as tabelas do banco de dados.

- [ ] Método OnModelCreating: Configura os mapeamentos e relacionamentos entre as entidades:

- [ ] UsuarioFinal: Define a chave primária e estabelece um relacionamento com Ingresso, onde a exclusão de um UsuarioFinal também exclui os ingressos relacionados.

- [ ] UsuarioAdm: Define a chave primária e permite que um UsuarioAdm gerencie várias Organizacoes.

- [ ] Organizacao: Define a chave primária e estabelece um relacionamento com Evento, onde a exclusão de uma Organizacao também exclui os eventos relacionados.

- [ ] Evento: Define a chave primária e permite que vários UsuarioFinal participem de eventos.

- [ ] Ingresso: Define a chave primária e estabelece um relacionamento com Evento, onde a exclusão de um Evento também exclui os ingressos relacionados.