### PR TITLE
Add HttpDelete endpoint and clean up using directives

### DIFF
--- a/EventPlanApp.Api/Controllers/EventoController.cs
+++ b/EventPlanApp.Api/Controllers/EventoController.cs
@@ -1,10 +1,6 @@
 ﻿using EventPlanApp.Application.DTOs;
 using EventPlanApp.Application.Interfaces;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace EventPlanApp.API.Controllers
 {
@@ -68,6 +64,24 @@ namespace EventPlanApp.API.Controllers
 
             var updatedEvent = await _eventoService.Update(id, eventoDto);
             return Ok(updatedEvent);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteEvent(int id)
+        {
+            var existingEvent = await _eventoService.GetById(id);
+            if (existingEvent == null)
+            {
+                return NotFound($"Event with ID {id} not found.");
+            }
+
+            var deleted = await _eventoService.Delete(id);
+            if (!deleted)
+            {
+                return BadRequest("Failed to delete the event.");
+            }
+
+            return NoContent();
         }
     }
 }


### PR DESCRIPTION
Removed unused `using` directives from `EventoController.cs` to clean up the code. Added a new `DeleteEvent` method as an HTTP DELETE endpoint to allow deletion of events by ID. The method checks for the event's existence, attempts deletion, and returns appropriate HTTP responses based on the outcome.