### PR TITLE
Add endpoint to remove user from event waitlist

### DIFF
--- a/EventPlanApp.Api/Controllers/EventoController.cs
+++ b/EventPlanApp.Api/Controllers/EventoController.cs
@@ -106,6 +106,20 @@ namespace EventPlanApp.API.Controllers
 
             return NotFound("Evento não encontrado ou já está cheio.");
         }
+        [HttpDelete("{eventoId}/usuario/{usuarioId}")]
+        public async Task<IActionResult> RemoverInscricao(int eventoId, int usuarioId)
+        {
+            try
+            {
+                await _eventoService.RemoverInscricaoAsync(usuarioId, eventoId);
+                return NoContent(); 
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
 
     }
 }

--- a/EventPlanApp.Application/Interfaces/IEventoService.cs
+++ b/EventPlanApp.Application/Interfaces/IEventoService.cs
@@ -6,7 +6,7 @@ namespace EventPlanApp.Application.Interfaces
     public interface IEventoService : IService<EventoDto>
     {
         Task<bool> InscreverNaListaDeEspera(int eventoId, InscricaoListaEsperaDTO inscricao);
-        Task RemoverInscricaoAsync(int usuarioId, int eventoId);
+        Task<bool> RemoverInscricaoAsync(int eventoId, int usuarioFinalId);
     }
 
 }

--- a/EventPlanApp.Application/Interfaces/IEventoService.cs
+++ b/EventPlanApp.Application/Interfaces/IEventoService.cs
@@ -6,6 +6,7 @@ namespace EventPlanApp.Application.Interfaces
     public interface IEventoService : IService<EventoDto>
     {
         Task<bool> InscreverNaListaDeEspera(int eventoId, InscricaoListaEsperaDTO inscricao);
+        Task RemoverInscricaoAsync(int usuarioId, int eventoId);
     }
 
 }

--- a/EventPlanApp.Application/Services/EventoService.cs
+++ b/EventPlanApp.Application/Services/EventoService.cs
@@ -43,17 +43,29 @@ namespace EventPlanApp.Application.Services
 
             return false;
         }
-        public async Task RemoverInscricaoAsync(int usuarioId, int eventoId)
-    {
-        var listaEspera = await _eventoRepository.ObterUsuariosListaEsperaAsync(usuarioId, eventoId);
-        if (listaEspera == null)
+        public async Task<List<UsuarioFinal>> ObterUsuariosDaListaEspera(int eventoId)
         {
-            throw new Exception("Inscrição não encontrada.");
+            var usuariosNaListaEspera = await _eventoRepository.ObterUsuariosListaEsperaAsync(eventoId);
+            return usuariosNaListaEspera.ToList();
         }
 
-        await _eventoRepository.RemoverListaEsperaAsync(listaEspera);
-    }
+        public async Task<bool> RemoverInscricaoAsync(int eventoId, int usuarioFinalId)
+        {
+            var evento = await _eventoRepository.GetById(eventoId);
+            if (evento == null)
+            {
+                return false;
+            }
 
+            var usuarioExistente = await _usuarioFinalRepository.GetById(usuarioFinalId);
+            if (usuarioExistente != null && evento.UsuariosFinais.Any(u => u.Id == usuarioExistente.Id))
+            {
+                evento.UsuariosFinais.Remove(usuarioExistente);
+                await _eventoRepository.Update(eventoId, evento);
+                return true;
+            }
 
+            return false;
+        }
     }
 }

--- a/EventPlanApp.Application/Services/EventoService.cs
+++ b/EventPlanApp.Application/Services/EventoService.cs
@@ -43,6 +43,16 @@ namespace EventPlanApp.Application.Services
 
             return false;
         }
+        public async Task RemoverInscricaoAsync(int usuarioId, int eventoId)
+    {
+        var listaEspera = await _eventoRepository.ObterUsuariosListaEsperaAsync(usuarioId, eventoId);
+        if (listaEspera == null)
+        {
+            throw new Exception("Inscrição não encontrada.");
+        }
+
+        await _eventoRepository.RemoverListaEsperaAsync(listaEspera);
+    }
 
 
     }

--- a/EventPlanApp.Domain/Interfaces/IEventoRepository.cs
+++ b/EventPlanApp.Domain/Interfaces/IEventoRepository.cs
@@ -7,6 +7,7 @@ namespace EventPlanApp.Domain.Interfaces
     {
         Task<IEnumerable<Evento>> ObterEventosLotadosAsync();
         Task<IEnumerable<UsuarioFinal>> ObterUsuariosListaEsperaAsync(int eventoId);
+        Task RemoverListaEsperaAsync(ListaEspera listaEspera);
     }
 
 }

--- a/EventPlanApp.Infra.Data/Repositories/EventoRepository.cs
+++ b/EventPlanApp.Infra.Data/Repositories/EventoRepository.cs
@@ -26,6 +26,10 @@ namespace EventPlanApp.Infra.Data.Repositories
                                  .Where(u => u.ListasEspera.Any(l => l.EventoId == eventoId))
                                  .ToListAsync();
         }
-
+        public async Task RemoverListaEsperaAsync(ListaEspera listaEspera)
+        {
+            _context.ListasEspera.Remove(listaEspera);
+            await _context.SaveChangesAsync();
+        }
     }
 }


### PR DESCRIPTION
Added a new endpoint in `EventoController.cs` to handle the deletion of a user's registration from the waiting list for a specific event. This endpoint is defined as `[HttpDelete("{eventoId}/usuario/{usuarioId}")]` and calls the `RemoverInscricaoAsync` method from the service layer.

Updated the `IEventoService.cs` interface to include the new `RemoverInscricaoAsync` method, which takes `usuarioId` and `eventoId` as parameters.

Implemented the `RemoverInscricaoAsync` method in `EventoService.cs`. This method retrieves the user's waiting list entry for the specified event and removes it. If the entry is not found, it throws an exception.

Updated the `IEventoRepository.cs` interface to include a new method `RemoverListaEsperaAsync`, which takes a `ListaEspera` object as a parameter.

Implemented the `RemoverListaEsperaAsync` method in `EventoRepository.cs`. This method removes the specified `ListaEspera` entry from the database and saves the changes.