### PR TITLE
Add endpoint to update event password and notify guests

### DIFF
--- a/EventPlanApp.Application/Interfaces/IEventoService.cs
+++ b/EventPlanApp.Application/Interfaces/IEventoService.cs
@@ -9,6 +9,7 @@ namespace EventPlanApp.Application.Interfaces
         Task<bool> RemoverInscricaoAsync(int eventoId, int usuarioFinalId);
         Task<bool> ValidarSenha(int eventoId, string senha);
         string HashPassword(string senha);
+        Task<bool> UpdateEventPassword(int eventoId, string novaSenha);
     }
 
 }

--- a/EventPlanApp.Application/Services/EventoService.cs
+++ b/EventPlanApp.Application/Services/EventoService.cs
@@ -116,5 +116,20 @@ namespace EventPlanApp.Application.Services
             await _eventoRepository.Add(evento);
         }
 
+        public async Task<bool> UpdateEventPassword(int eventoId, string novaSenha)
+        {
+            var evento = await _eventoRepository.GetById(eventoId);
+            if (evento == null)
+            {
+                return false;
+            }
+
+            evento.PasswordHash = HashPassword(novaSenha);
+            await _eventoRepository.Update(eventoId, evento);
+
+            return true;
+        }
+
+
     }
 }


### PR DESCRIPTION
A new endpoint has been added to the `EventoController` class to allow updating the password of an event via an HTTP PUT request at the route `"{id}/senha"`. The `UpdateEventPassword` method checks for the new password, updates it using `_eventoService`, and sends email notifications to all invited guests if applicable.

The `IEventoService` interface now includes the `UpdateEventPassword` method, which is implemented in the `EventoService` class. This method retrieves the event by its ID, updates its password hash, and saves the changes to the repository.