### PR TITLE
ImplementarRemocaoDeEventoDosFavoritos

### DIFF
--- a/EventPlanApp.Api/Controllers/FavoritesController.cs
+++ b/EventPlanApp.Api/Controllers/FavoritesController.cs
@@ -1,4 +1,4 @@
-﻿using EventPlanApp.Application.Interfaces;
+﻿using EventPlanApp.Application.Services;
 using EventPlanApp.Domain.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -52,6 +52,28 @@ namespace EventPlanApp.Api.Controllers
             }
 
             return Ok(favorites);
+        }
+        [HttpDelete("{eventId}")]
+        public async Task<IActionResult> RemoveFromFavorites(int eventoId)
+        {
+            // Recupera o ID do usuário autenticado
+            var userId = User.Identity.Name;
+
+            // Verifica se o evento está nos favoritos
+            var isFavorited = await _favoritesRepository.IsEventFavoritedByUserAsync(userId, eventoId);
+            if (!isFavorited)
+            {
+                return BadRequest("Este evento não está nos favoritos.");
+            }
+
+            // Remove o evento dos favoritos
+            var result = await _favoriteService.RemoveFromFavoritesAsync(userId, eventoId);
+            if (result)
+            {
+                return Ok("Evento removido dos favoritos.");
+            }
+
+            return StatusCode(500, "Erro ao remover o evento dos favoritos.");
         }
     }
 }

--- a/EventPlanApp.Application/Interfaces/IFavoriteService.cs
+++ b/EventPlanApp.Application/Interfaces/IFavoriteService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventPlanApp.Application.Interfaces
+{
+    public interface IFavoriteService
+    {
+    }
+}

--- a/EventPlanApp.Application/Services/FavoriteService.cs
+++ b/EventPlanApp.Application/Services/FavoriteService.cs
@@ -1,13 +1,14 @@
 ﻿using AutoMapper;
 using EventPlanApp.Application.DTOs;
 using EventPlanApp.Domain.Interfaces;
+using EventPlanApp.Infra.Data.Repositories;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace EventPlanApp.Application.Interfaces
+namespace EventPlanApp.Application.Services
 {
     public class FavoriteService
     {
@@ -26,6 +27,12 @@ namespace EventPlanApp.Application.Interfaces
 
             // Retorna os eventos favoritos mapeados para DTOs
             return favorites.Select(f => _mapper.Map<EventoDto>(f.Evento)).ToList();
+        }
+        public async Task<bool> RemoveFromFavoritesAsync(string userId, int eventId)
+        {
+            // Remove a relação entre o usuário e o evento no banco de dados
+            var success = await _favoriteRepository.RemoveFavoriteAsync(userId, eventId);
+            return success;
         }
     }
 }

--- a/EventPlanApp.Domain/Interfaces/IFavoritesRepository.cs
+++ b/EventPlanApp.Domain/Interfaces/IFavoritesRepository.cs
@@ -12,5 +12,8 @@ namespace EventPlanApp.Domain.Interfaces
         Task<bool> IsEventFavoritedByUserAsync(string userId, int eventoId);
         Task AddToFavoritesAsync(string userId, int eventoId);
         Task<IEnumerable<Favorite>> GetFavoritesByUserIdAsync(string userId);
+
+        Task<bool> RemoveFavoriteAsync(string userId, int eventoId);
     }
+
 }

--- a/EventPlanApp.Infra.Data/Repositories/FavoritesRepository.cs
+++ b/EventPlanApp.Infra.Data/Repositories/FavoritesRepository.cs
@@ -44,5 +44,16 @@ namespace EventPlanApp.Infra.Data.Repositories
                 .OrderBy(f => f.Evento.DataInicio)  // Ordenar pela data de início do evento
                 .ToListAsync();
         }
+        public async Task<bool> RemoveFavoriteAsync(string userId, int eventoId)
+        {
+            // Remove a relação entre o usuário e o evento
+            var favorite = await _context.Favorites
+                                          .FirstOrDefaultAsync(f => f.UserId == userId && f.EventoId == eventoId);
+            if (favorite == null) return false;
+
+            _context.Favorites.Remove(favorite);
+            await _context.SaveChangesAsync();
+            return true;
+        }
     }
 }


### PR DESCRIPTION
- [ ] Implementar a funcionalidade para remover eventos da lista de favoritos de um usuário.
- [ ] Criar endpoints e lógica de serviço para a exclusão de eventos dos favoritos.
- [ ] Garantir a consistência e a integridade dos dados ao remover a relação entre o usuário e o evento nos favoritos.
- [ ] Criação do Endpoint DELETE:
- [ ] Adicionada uma nova rota DELETE /api/favorites/{eventId} no controlador FavoritesController para permitir que o usuário remova um evento dos seus favoritos.
- [ ] Validação no Controller:
- [ ] Verificação se o evento está nos favoritos do usuário antes de permitir a remoção.
- [ ] Se o evento não estiver nos favoritos, retorna um BadRequest com a mensagem "Este evento não está nos favoritos".
- [ ] Caso o evento seja encontrado nos favoritos, a remoção é realizada chamando o serviço correspondente.
- [ ] Lógica de Remoção no Serviço:
- [ ] Implementado o método RemoveFromFavoritesAsync no serviço FavoriteService para remover a relação entre o usuário e o evento no banco de dados.
- [ ] A lógica verifica a presença do evento nos favoritos antes de proceder com a exclusão.
- [ ] Modificação no Repositório:
- [ ] O repositório FavoritesRepository foi atualizado para incluir o método RemoveFavoriteAsync, que remove a relação de favorito entre o usuário e o evento no banco de dados.
- [ ] O controlador FavoritesController recebe a requisição DELETE /api/favorites/{eventId}.
- [ ] O método RemoveFromFavorites verifica se o evento está nos favoritos do usuário usando o método IsEventFavoritedByUserAsync.
- [ ] Se o evento estiver nos favoritos, o método chama FavoriteService.RemoveFromFavoritesAsync para remover a relação no banco de dados.
- [ ] Caso contrário, retorna um BadRequest.
- [ ] Em caso de sucesso, retorna um Ok com a mensagem "Evento removido dos favoritos".
- [ ] Em caso de falha na remoção, retorna um erro interno StatusCode(500).
- [ ] Teste 1: RemoveFromFavorites_EventNotFavorited_ShouldReturnBadRequest
- [ ] Testa o comportamento quando o evento não está nos favoritos do usuário. O resultado esperado é um BadRequest com a mensagem "Este evento não está nos favoritos".
- [ ] Teste 2: RemoveFromFavorites_SuccessfullyRemoved_ShouldReturnOk
- [ ] Testa o comportamento quando o evento é removido com sucesso dos favoritos. O resultado esperado é um Ok com a mensagem "Evento removido dos favoritos".
- [ ] Os testes utilizam o Moq para simular o comportamento do repositório e garantir que a lógica de remoção e verificação de favoritos esteja funcionando corretamente.
- [ ] Ao remover um evento dos favoritos, a relação entre o usuário e o evento é excluída da tabela de favoritos no banco de dados.
- [ ] A operação de remoção é executada de forma atômica, utilizando o método RemoveFavoriteAsync no repositório.
- [ ] FavoriteService: Serviço responsável pela lógica de negócios da remoção de eventos dos favoritos.
- [ ] FavoritesRepository: Repositório que interage com o banco de dados para verificar e remover os eventos dos favoritos.
- [ ] Controller: Controlador que expõe o endpoint para a remoção de eventos dos favorito