### PR TITLE
Add category management and Azure deployment

### DIFF
--- a/.github/workflows/EventPlan.yml
+++ b/.github/workflows/EventPlan.yml
@@ -44,7 +44,7 @@ jobs:
       run: dotnet tool install --global Swashbuckle.AspNetCore.Cli --version ${{ env.SWASHBUCLE_ASPNET_CORE_CLI_PACKAGE_VERSION }}
       working-directory: ${{ env.WORKING_DIRECTORY }}
     - name: Generate Open API Specification Document
-      run: swagger tofile --output "${{ env.API_IMPORT_SPECIFICATION_PATH }}" "${{ env.API_IMPORT_DLL }}" "${{ env.API_IMPORT_VERSION }}"
+      run: swagger tofile --output "EventPlanApp.Api\publish\swagger.json" "EventPlanApp.Api\bin\Release\net6.0\EventPlanApp.Api.dll" "v1" --startup-class "EventPlanApp.Api.Program"
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/EventPlan.yml
+++ b/.github/workflows/EventPlan.yml
@@ -57,16 +57,16 @@ jobs:
       with:
         name: webapp
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+    - name: Azure Login
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.EventPlanAppApiapi_SPN }} 
     - name: Deploy to Azure WebApp
       uses: azure/webapps-deploy@v2
       with:
         app-name: ${{ env.AZURE_WEBAPP_NAME }}
         package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
         publish-profile: ${{ secrets.EventPlan_7E3F }}
-    - name: Azure Login
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.EventPlanAppApiapi_SPN }}
     - name: Import API into Azure API Management
       run: az apim api import --path "${{ env.AZURE_APIM_RESOURCE_PATH }}" --resource-group "${{ env.AZURE_APIM_RESOURCEGROUP }}" --service-name "${{ env.AZURE_APIM_SERVICENAME }}" --api-id "${{ env.AZURE_APIM_API_ID }}" --service-url "${{ env.AZURE_APIM_APPSERVICEURL }}" --specification-path "${{ env.API_IMPORT_SPECIFICATION_PATH }}" --specification-format OpenApi --subscription-required false
     - name: logout

--- a/.github/workflows/EventPlan.yml
+++ b/.github/workflows/EventPlan.yml
@@ -1,0 +1,76 @@
+name: Build and deploy .NET Core application to Web App EventPlan with API Management Service EventPlanAppApiapi-EventPlanApi
+on:
+  push:
+    branches:
+    - deployBack
+env:
+  AZURE_WEBAPP_NAME: EventPlan
+  AZURE_WEBAPP_PACKAGE_PATH: EventPlanApp.Api\publish
+  AZURE_APIM_RESOURCE_PATH: /EventPlan
+  AZURE_APIM_RESOURCEGROUP: EventPlan
+  AZURE_APIM_SERVICENAME: EventPlanAppApiapi
+  AZURE_APIM_API_ID: EventPlanApi
+  AZURE_APIM_APPSERVICEURL: https://eventplan-c2ddc0chgybpfjba.eastus-01.azurewebsites.net
+  SWASHBUCLE_ASPNET_CORE_CLI_PACKAGE_VERSION: 5.6.3
+  SWASHBUCKLE_DOTNET_CORE_VERSION: 3.1.x
+  API_IMPORT_SPECIFICATION_PATH: EventPlanApp.Api\publish\swagger.json
+  API_IMPORT_DLL: EventPlanApp.Api\bin\Release\net6.0\EventPlanApp.Api.dll
+  API_IMPORT_VERSION: v1
+  CONFIGURATION: Release
+  DOTNET_CORE_VERSION: 6.0.x
+  WORKING_DIRECTORY: EventPlanApp.Api
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
+    - name: Setup SwashBuckle .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.SWASHBUCKLE_DOTNET_CORE_VERSION }}
+    - name: Restore
+      run: dotnet restore ${{ env.WORKING_DIRECTORY }}
+    - name: Build
+      run: dotnet build ${{ env.WORKING_DIRECTORY }} --configuration ${{ env.CONFIGURATION }} --no-restore
+    - name: Test
+      run: dotnet test ${{ env.WORKING_DIRECTORY }} --no-build
+    - name: Publish
+      run: dotnet publish ${{ env.WORKING_DIRECTORY }} --configuration ${{ env.CONFIGURATION }} --no-build --output ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+    - name: Install Swashbuckle CLI .NET Global Tool
+      run: dotnet tool install --global Swashbuckle.AspNetCore.Cli --version ${{ env.SWASHBUCLE_ASPNET_CORE_CLI_PACKAGE_VERSION }}
+      working-directory: ${{ env.WORKING_DIRECTORY }}
+    - name: Generate Open API Specification Document
+      run: swagger tofile --output "${{ env.API_IMPORT_SPECIFICATION_PATH }}" "${{ env.API_IMPORT_DLL }}" "${{ env.API_IMPORT_VERSION }}"
+    - name: Publish Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: webapp
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+  deploy:
+    runs-on: windows-latest
+    needs: build
+    steps:
+    - name: Download artifact from build job
+      uses: actions/download-artifact@v3
+      with:
+        name: webapp
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+    - name: Deploy to Azure WebApp
+      uses: azure/webapps-deploy@v2
+      with:
+        app-name: ${{ env.AZURE_WEBAPP_NAME }}
+        package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+        publish-profile: ${{ secrets.EventPlan_7E3F }}
+    - name: Azure Login
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.EventPlanAppApiapi_SPN }}
+    - name: Import API into Azure API Management
+      run: az apim api import --path "${{ env.AZURE_APIM_RESOURCE_PATH }}" --resource-group "${{ env.AZURE_APIM_RESOURCEGROUP }}" --service-name "${{ env.AZURE_APIM_SERVICENAME }}" --api-id "${{ env.AZURE_APIM_API_ID }}" --service-url "${{ env.AZURE_APIM_APPSERVICEURL }}" --specification-path "${{ env.API_IMPORT_SPECIFICATION_PATH }}" --specification-format OpenApi --subscription-required false
+    - name: logout
+      run: >
+        az logout

--- a/.github/workflows/EventPlan.yml
+++ b/.github/workflows/EventPlan.yml
@@ -43,8 +43,6 @@ jobs:
     - name: Install Swashbuckle CLI .NET Global Tool
       run: dotnet tool install --global Swashbuckle.AspNetCore.Cli --version ${{ env.SWASHBUCLE_ASPNET_CORE_CLI_PACKAGE_VERSION }}
       working-directory: ${{ env.WORKING_DIRECTORY }}
-    - name: Generate Open API Specification Document
-      run: swagger tofile --output "EventPlanApp.Api\publish\swagger.json" "EventPlanApp.Api\bin\Release\net6.0\EventPlanApp.Api.dll" "v1" --startup-class "EventPlanApp.Api.Program"
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/EventPlanApp.Api/Controllers/CategoryController.cs
+++ b/EventPlanApp.Api/Controllers/CategoryController.cs
@@ -1,0 +1,32 @@
+﻿using AutoMapper;
+using EventPlanApp.Application.DTOs;
+using EventPlanApp.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EventPlanApp.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CategoryController : ControllerBase
+{
+    private readonly ICategoryService _categoryService;
+
+    public CategoryController(ICategoryService categoryService)
+    {
+        _categoryService = categoryService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetCategories()
+    {
+        try
+        {
+            var categories = await _categoryService.GetAll();
+            return Ok(categories);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { message = ex.Message });
+        }
+    }
+}

--- a/EventPlanApp.Api/Controllers/EventoController.cs
+++ b/EventPlanApp.Api/Controllers/EventoController.cs
@@ -184,42 +184,12 @@ namespace EventPlanApp.API.Controllers
 
 
         [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateEvent(int id, [FromBody] Evento eventoAtualizado)
+        public async Task<IActionResult> UpdateEvent(int id,[FromBody] EventoDto eventoDto)
         {
-            if (id != eventoAtualizado.EventoId)
-            {
-                return BadRequest("O ID do evento na URL não corresponde ao ID do evento no corpo da requisição.");
-            }
-
-            try
-            {
-                if (!ModelState.IsValid)
-                {
-                    return BadRequest(ModelState);
-                }
-
-                var eventoExistente = await _eventoRepository.GetByIdAsync(id);
-                if (eventoExistente == null)
-                {
-                    return NotFound("Evento não encontrado.");
-                }
-
-                eventoExistente.AtualizarEvento(
-                    eventoAtualizado.NomeEvento,
-                    eventoAtualizado.DataInicio,
-                    eventoAtualizado.DataFim,
-                    eventoAtualizado.HorarioInicio,
-                    eventoAtualizado.HorarioFim,
-                    eventoAtualizado.LotacaoMaxima
-                );
-
-                await _eventoRepository.UpdateAsync(eventoExistente);
-                return NoContent(); // 204 No Content
-            }
-            catch (Exception ex)
-            {
-                return StatusCode(500, $"Erro ao atualizar o evento: {ex.Message}");
-            }
+            
+                await _eventoService.Update(id, eventoDto);
+                return NoContent(); 
+            
         }
 
         [HttpPut("{id}/senha")]
@@ -640,53 +610,5 @@ namespace EventPlanApp.API.Controllers
             var estatisticas = await _eventoEstatisticasService.ObterEstatisticasPorEventoAsync(eventoId);
             return Ok(estatisticas);
         }
-
-        
-
-        [HttpGet("{obter-evento-por-id}")]
-        public async Task<IActionResult> GetEvento(int id)
-        {
-            var evento = await _eventoService.ObterEventoPorIdAsync(id);
-            if (evento == null)
-                return NotFound();
-
-            return Ok(evento);
-        }
-
-        [HttpPost("criar-evento")]
-        public async Task<IActionResult> CreateEvento([FromBody] Evento evento)
-        {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            await _eventoService.CriarEventoAsync(evento);
-            return CreatedAtAction(nameof(GetEvento), new { id = evento.EventoId }, evento);
-        }
-
-        [HttpPut("{atualizat-evento}")]
-        public async Task<IActionResult> UpdateEvento(int id, [FromBody] Evento evento)
-        {
-            if (id != evento.EventoId)
-                return BadRequest();
-
-            var eventoExistente = await _eventoService.ObterEventoPorIdAsync(id);
-            if (eventoExistente == null)
-                return NotFound();
-
-            await _eventoService.AtualizarEventoAsync(evento);
-            return NoContent();
-        }
-
-        [HttpDelete("{deletar-evento}")]
-        public async Task<IActionResult> DeleteEvento(int id)
-        {
-            var eventoExistente = await _eventoService.ObterEventoPorIdAsync(id);
-            if (eventoExistente == null)
-                return NotFound();
-
-            await _eventoService.DeletarEventoAsync(id);
-            return NoContent();
-        }
-
     }
 }

--- a/EventPlanApp.Api/Controllers/OrganizationsController.cs
+++ b/EventPlanApp.Api/Controllers/OrganizationsController.cs
@@ -34,7 +34,7 @@ namespace EventPlanApp.Api.Controllers
             return BadRequest(result.Message);
         }
 
-        [HttpGet("{id}/status")]
+        [HttpGet("{id}")]
         public async Task<IActionResult> GetStatus(int id)
         {
             var organizacao = await _organizacaoRepository.GetByIdAsync(id);
@@ -43,7 +43,7 @@ namespace EventPlanApp.Api.Controllers
                 return NotFound("Organização não encontrada.");
             }
 
-            return Ok(new { Status = organizacao.Status }); // Retornar o status
+            return Ok();
         }
     }
 }

--- a/EventPlanApp.Api/Properties/ServiceDependencies/EventPlan/apis1.arm.json
+++ b/EventPlanApp.Api/Properties/ServiceDependencies/EventPlan/apis1.arm.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceGroupName": {
+      "type": "string",
+      "defaultValue": "EventPlan",
+      "metadata": {
+        "_parameterType": "resourceGroup",
+        "description": "Name of the resource group for the resource. It is recommended to put resources under same resource group for better tracking."
+      }
+    },
+    "resourceGroupLocation": {
+      "type": "string",
+      "defaultValue": "eastus",
+      "metadata": {
+        "_parameterType": "location",
+        "description": "Location of the resource group. Resource groups could have different location than resources."
+      }
+    },
+    "resourceLocation": {
+      "type": "string",
+      "defaultValue": "[parameters('resourceGroupLocation')]",
+      "metadata": {
+        "_parameterType": "location",
+        "description": "Location of the resource. By default use resource group's location, unless the resource provider is not supported there."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[parameters('resourceGroupLocation')]",
+      "apiVersion": "2019-10-01"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(parameters('resourceGroupName'), 'Deployment', uniqueString(concat('EventPlanApi', subscription().subscriptionId)))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "apiVersion": "2019-10-01",
+      "dependsOn": [
+        "[parameters('resourceGroupName')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [
+            {
+              "name": "EventPlanAppApiapi",
+              "type": "Microsoft.ApiManagement/service",
+              "location": "[parameters('resourceLocation')]",
+              "properties": {
+                "publisherEmail": "rhian.souza@fatec.sp.gov.br",
+                "publisherName": "RHIAN MENDES SOUZA",
+                "notificationSenderEmail": "apimgmt-noreply@mail.windowsazure.com",
+                "hostnameConfigurations": [
+                  {
+                    "type": "Proxy",
+                    "hostName": "eventplanappapiapi.azure-api.net",
+                    "encodedCertificate": null,
+                    "keyVaultId": null,
+                    "certificatePassword": null,
+                    "negotiateClientCertificate": false,
+                    "certificate": null,
+                    "defaultSslBinding": true
+                  }
+                ],
+                "publicIPAddresses": null,
+                "privateIPAddresses": null,
+                "additionalLocations": null,
+                "virtualNetworkConfiguration": null,
+                "customProperties": {
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "False",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11": "False",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls10": "False",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11": "False",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30": "False",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Protocols.Server.Http2": "False"
+                },
+                "virtualNetworkType": "None",
+                "certificates": null,
+                "disableGateway": false,
+                "apiVersionConstraint": {
+                  "minApiVersion": null
+                }
+              },
+              "sku": {
+                "name": "Consumption",
+                "capacity": 0
+              },
+              "apiVersion": "2019-12-01"
+            },
+            {
+              "type": "Microsoft.ApiManagement/service/apis",
+              "name": "EventPlanAppApiapi/EventPlanApi",
+              "properties": {
+                "displayName": "EventPlanApi",
+                "apiRevision": "1",
+                "description": null,
+                "subscriptionRequired": true,
+                "serviceUrl": null,
+                "path": "EventPlan",
+                "protocols": [
+                  "https"
+                ],
+                "authenticationSettings": {
+                  "oAuth2": null,
+                  "openid": null
+                },
+                "subscriptionKeyParameterNames": {
+                  "header": "Ocp-Apim-Subscription-Key",
+                  "query": "subscription-key"
+                },
+                "isCurrent": true
+              },
+              "apiVersion": "2019-12-01",
+              "dependsOn": [
+                "EventPlanAppApiapi"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "_dependencyType": "apis.azure"
+  }
+}

--- a/EventPlanApp.Api/Properties/serviceDependencies.EventPlan.json
+++ b/EventPlanApp.Api/Properties/serviceDependencies.EventPlan.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "apis1": {
+      "resourceId": "/subscriptions/[parameters('subscriptionId')]/resourceGroups/[parameters('resourceGroupName')]/providers/Microsoft.ApiManagement/service/EventPlanAppApiapi/apis/EventPlanApi",
+      "type": "apis.azure"
+    }
+  }
+}

--- a/EventPlanApp.Api/Properties/serviceDependencies.json
+++ b/EventPlanApp.Api/Properties/serviceDependencies.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "apis1": {
+      "type": "apis"
+    }
+  }
+}

--- a/EventPlanApp.Application/DTOs/CategoryDTO.cs
+++ b/EventPlanApp.Application/DTOs/CategoryDTO.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventPlanApp.Application.DTOs
+{
+    public class CategoryDTO
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/EventPlanApp.Application/Interfaces/ICategoryService.cs
+++ b/EventPlanApp.Application/Interfaces/ICategoryService.cs
@@ -1,0 +1,14 @@
+﻿using EventPlanApp.Application.DTOs;
+using EventPlanApp.Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventPlanApp.Application.Interfaces
+{
+    public interface ICategoryService : IService<CategoryDTO>
+    {
+    }
+}

--- a/EventPlanApp.Application/Interfaces/IEventoService.cs
+++ b/EventPlanApp.Application/Interfaces/IEventoService.cs
@@ -21,10 +21,6 @@ namespace EventPlanApp.Application.Interfaces
         Task<IEnumerable<HistoricoDeEventoDto>> ObterHistoricoDeEventosComEngajamentoAsync(int organizadorId);
         Task<Evento> ObterEventoPorIdAsync(int id);
         Task<List<Evento>> ObterTodosEventosAsync();
-        Task CriarEventoAsync(Evento evento);
-        Task AtualizarEventoAsync(Evento evento);  // Adicione esta linha
-        Task DeletarEventoAsync(int id);
-
 
     }
 

--- a/EventPlanApp.Application/Services/CategoryService.cs
+++ b/EventPlanApp.Application/Services/CategoryService.cs
@@ -1,0 +1,19 @@
+﻿using AutoMapper;
+using EventPlanApp.Application.DTOs;
+using EventPlanApp.Application.Interfaces;
+using EventPlanApp.Domain.Entities;
+using EventPlanApp.Domain.Interfaces;
+
+namespace EventPlanApp.Application.Services
+{
+    public class CategoryService : ServiceBase<CategoryDTO, Categoria>, ICategoryService
+    {
+        private readonly ICategoryRepository _categoryRepository;
+
+        public CategoryService(ICategoryRepository categoryRepository, IMapper mapper)
+            : base(categoryRepository, mapper)
+        {
+            _categoryRepository = categoryRepository;
+        }
+    }
+}

--- a/EventPlanApp.Application/Services/EventoService.cs
+++ b/EventPlanApp.Application/Services/EventoService.cs
@@ -272,30 +272,6 @@ namespace EventPlanApp.Application.Services
             return await _context.Eventos.Include(e => e.Categoria)
                                          .FirstOrDefaultAsync(e => e.EventoId == id);
         }
-
-        public async Task CriarEventoAsync(Evento evento)
-        {
-            await _context.Eventos.AddAsync(evento);
-            await _context.SaveChangesAsync();
-        }
-
-        public async Task AtualizarEventoAsync(Evento evento)
-        {
-            _context.Eventos.Update(evento);
-            await _context.SaveChangesAsync();
-        }
-
-        public async Task DeletarEventoAsync(int id)
-        {
-            var evento = await _context.Eventos.FindAsync(id);
-            if (evento != null)
-            {
-                _context.Eventos.Remove(evento);
-                await _context.SaveChangesAsync();
-            }
-        }
-
-
     }
 
 }

--- a/EventPlanApp.Domain/Entities/Categoria.cs
+++ b/EventPlanApp.Domain/Entities/Categoria.cs
@@ -4,15 +4,13 @@ namespace EventPlanApp.Domain.Entities
 {
     public class Categoria
     {
+        public Categoria(string nome)
+        {
+            Nome = nome;
+        }
+
         public int CategoriaId { get; private set; }
         public string Nome { get; private set; }
 
-        public Categoria(string nome)
-        {
-            if (string.IsNullOrWhiteSpace(nome))
-                throw new ArgumentException("Nome da categoria não pode ser nulo ou vazio.");
-
-            Nome = nome;
-        }
     }
 }

--- a/EventPlanApp.Domain/Interfaces/ICategoryRepository.cs
+++ b/EventPlanApp.Domain/Interfaces/ICategoryRepository.cs
@@ -1,0 +1,13 @@
+﻿using EventPlanApp.Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventPlanApp.Domain.Interfaces
+{
+    public interface ICategoryRepository : IRepository<Categoria>
+    {
+    }
+}

--- a/EventPlanApp.Domain/Interfaces/IRepository.cs
+++ b/EventPlanApp.Domain/Interfaces/IRepository.cs
@@ -9,6 +9,5 @@ namespace EventPlanApp.Domain.Interfaces
         Task<T> Add(T entity);
         Task<T> Update(int id, T entity);
         Task<bool> Delete(int id);
-        Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate);
     }
 }

--- a/EventPlanApp.Infra.Data/Migrations/EventPlanContextModelSnapshot.cs
+++ b/EventPlanApp.Infra.Data/Migrations/EventPlanContextModelSnapshot.cs
@@ -52,6 +52,67 @@ namespace EventPlanApp.Infra.Data.Migrations
                     b.ToTable("UsuarioFinalEvento", (string)null);
                 });
 
+            modelBuilder.Entity("EventPlanApp.Domain.Entities.AuditLog", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+
+                    b.Property<string>("ActionType")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ConteudoAlteradoAntes")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ConteudoAlteradoDepois")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTime>("DataHora")
+                        .HasColumnType("datetime2");
+
+                    b.Property<DateTime>("Date")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("Descricao")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Details")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("EntityName")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("IpEndereco")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<bool>("IsSuspicious")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("TipoAcao")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<int>("UsuarioAdmId")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("AuditLogs", (string)null);
+                });
+
             modelBuilder.Entity("EventPlanApp.Domain.Entities.AvaliacaoEvento", b =>
                 {
                     b.Property<int>("AvaliacaoEventoId")
@@ -186,6 +247,9 @@ namespace EventPlanApp.Infra.Data.Migrations
                     b.Property<bool>("IsPrivate")
                         .HasColumnType("bit");
 
+                    b.Property<bool>("IsTaxaPercentual")
+                        .HasColumnType("bit");
+
                     b.Property<string>("ListaConvidadosSerializada")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
@@ -216,9 +280,18 @@ namespace EventPlanApp.Infra.Data.Migrations
                     b.Property<int>("Status")
                         .HasColumnType("int");
 
+                    b.Property<decimal>("TaxaServicoValor")
+                        .HasColumnType("decimal(18,2)");
+
                     b.Property<string>("Tipo")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<int>("TotalCancelamentos")
+                        .HasColumnType("int");
+
+                    b.Property<int>("TotalInscritos")
+                        .HasColumnType("int");
 
                     b.Property<string>("Video")
                         .IsRequired()
@@ -298,6 +371,9 @@ namespace EventPlanApp.Infra.Data.Migrations
                         .HasPrecision(10, 2)
                         .HasColumnType("decimal(10,2)");
 
+                    b.Property<decimal>("ValorFinal")
+                        .HasColumnType("decimal(18,2)");
+
                     b.Property<bool>("Vip")
                         .HasColumnType("bit");
 
@@ -360,6 +436,30 @@ namespace EventPlanApp.Infra.Data.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Roles", (string)null);
+                });
+
+            modelBuilder.Entity("EventPlanApp.Domain.Entities.TaxaServicoConfig", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+
+                    b.Property<int>("EventoId")
+                        .HasColumnType("int");
+
+                    b.Property<decimal?>("TaxaFixa")
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<decimal?>("TaxaPercentual")
+                        .HasColumnType("decimal(18,2)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventoId");
+
+                    b.ToTable("TaxaServicoConfig", (string)null);
                 });
 
             modelBuilder.Entity("EventPlanApp.Domain.Entities.UserPreferences", b =>
@@ -451,6 +551,9 @@ namespace EventPlanApp.Infra.Data.Migrations
                     b.Property<int>("EnderecoId")
                         .HasColumnType("int");
 
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("bit");
+
                     b.Property<string>("Nome")
                         .IsRequired()
                         .HasMaxLength(100)
@@ -481,7 +584,7 @@ namespace EventPlanApp.Infra.Data.Migrations
 
                     b.HasIndex("RoleId");
 
-                    b.ToTable("UsuariosFinais", (string)null);
+                    b.ToTable("UsuarioFinal", (string)null);
                 });
 
             modelBuilder.Entity("EventPlanApp.Domain.Entities.Volunteer", b =>
@@ -741,6 +844,17 @@ namespace EventPlanApp.Infra.Data.Migrations
                     b.Navigation("Evento");
 
                     b.Navigation("UsuarioFinal");
+                });
+
+            modelBuilder.Entity("EventPlanApp.Domain.Entities.TaxaServicoConfig", b =>
+                {
+                    b.HasOne("EventPlanApp.Domain.Entities.Evento", "Evento")
+                        .WithMany()
+                        .HasForeignKey("EventoId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Evento");
                 });
 
             modelBuilder.Entity("EventPlanApp.Domain.Entities.UsuarioAdm", b =>

--- a/EventPlanApp.Infra.Data/Repositories/CategoryRepository.cs
+++ b/EventPlanApp.Infra.Data/Repositories/CategoryRepository.cs
@@ -1,0 +1,20 @@
+﻿using EventPlanApp.Domain.Entities;
+using EventPlanApp.Domain.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventPlanApp.Infra.Data.Repositories
+{
+    public class CategoryRepository : BaseRepository<Categoria>, ICategoryRepository
+    {
+        private readonly EventPlanContext _context;
+
+        public CategoryRepository(EventPlanContext context) : base(context)
+        {
+            _context = context;
+        }
+    }
+}


### PR DESCRIPTION
- Added a new GitHub Actions workflow in `EventPlan.yml` to build and deploy a .NET Core application to an Azure Web App and import the API into Azure API Management Service.
- Introduced `CategoryController`, `CategoryDTO`, `ICategoryService`, `CategoryService`, `ICategoryRepository`, and `CategoryRepository` for category management.
- Updated `EventoController.cs` and `EventoService.cs` to use `EventoDto` and removed redundant event management methods.
- Modified `OrganizationsController.cs` to change the endpoint for getting the status of an organization.
- Added a new ARM template `apis1.arm.json` for deploying API Management resources in Azure.
- Updated `serviceDependencies.EventPlan.json` and `serviceDependencies.json` to include dependencies for the new API Management resources.
- Updated `IEventoService.cs` and `IRepository.cs` to remove unused methods.
- Modified `Categoria.cs` to change the access modifiers of properties.
- Added new entity configurations in `EventPlanContextModelSnapshot.cs` for `AuditLog`, `TaxaServicoConfig`, and other entities.